### PR TITLE
feat: add custom python version for setup.sh

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 Google_Gemini_API_Key="your_gemini_api_key"
 Telegram_Bot_Token="your_telegram_bot_token"
+Python_Bin_Path=""
+Python_Venv_Path="venv"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ for yihong0618's channel: https://t.me/hyi0618
 4. Edit .env file and change the following variables
     - Google_Gemini_API_Key (Google Gemini API KEY)
     - Telegram_Bot_Token (Telegram Bot Token)
+    - Python_Bin_Path (If you install python alternative version, you can use this to specify the python bin path. Default is blank or /usr/bin/python3)
+    - Python_Venv_Path (Python virtualenv path. Default is venv)
+
 5. Run ```chmod +x setup.sh && ./setup.sh``` or ``` bash setup.sh ``` to install and run
 
 6. Run ```systemctl status tgbotyh``` to check the status
@@ -38,8 +41,16 @@ for yihong0618's channel: https://t.me/hyi0618
 8. Run ```systemctl stop tgbotyh``` to stop the service
 9. Run ```systemctl restart tgbotyh``` to restart the service
 
-### Manually install 
+### Run with command line with Python virtualenv environment
+1. Git clone this repo
+2. cd tg_bot_collections
+3. Copy file .env.example to .env 
+4. Edit .env file and change the following variables (Same as above that Run with systemd service)
+5. Run ```chmod +x run.sh && ./run.sh``` or ``` bash run.sh ``` to install and run
+6. Ctrl + C to quit and Run ```deactivate``` to exit the virtualenv environment
+7. Next time, you can run ```./run.sh``` or ``` bash run.sh ``` to run the bot
 
+### Manually install 
 1. pip install -r requirements.txt
 2. Get tg token, ask Google or ChatGPT, need get it from [BotFather](https://t.me/BotFather)
 3. export GOOGLE_GEMINI_KEY=${your_google_gemini_apikey}

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+python_bin_path="$(which python3)"
+venv_dir="venv"
+project_path="$(pwd)"
+
+source .env
+
+google_gemini_api_key="${Google_Gemini_API_Key}"
+telegram_bot_token="${Telegram_Bot_Token}"
+
+if [ -n "$Python_Venv_Path" ]; then
+    venv_dir="${Python_Venv_Path}"
+fi
+
+if [ -n "$Python_Bin_Path" ]; then
+    python_bin_path="$Python_Bin_Path"
+fi
+
+echo "=============================="
+echo "Prapare to run telegram bot"
+echo ""
+echo "Project path: $project_path"
+echo "Python bin path: $python_bin_path"
+echo "Google_Gemini_API_Key: $Google_Gemini_API_Key"
+echo "Telegram Bot Token: $Telegram_Bot_Token"
+echo ""
+
+# Check Virtual Environment exist
+if [ -d "$venv_dir" ]; then
+    echo "Virtual Environment already exist"
+    source $venv_dir/bin/activate
+else
+    # created virtual environment
+    echo "Creating virtual environment..."
+    $python_bin_path -m venv "$venv_dir"
+
+    if [ $? -eq 0 ]; then
+        echo "Successfully created virtual environment."
+    else
+        echo "Failed to create virtual environment."
+    fi
+
+    source $venv_dir/bin/activate
+    python -m pip install --upgrade pip
+    pip install -r requirements.txt
+fi
+
+echo "=============================="
+export GOOGLE_GEMINI_KEY=$google_gemini_api_key
+python tg.py "${telegram_bot_token}"

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 python_bin_path="$(which python3)"
-venv_dir="venv"
 
 project_path="$(pwd)"
 service_name="tgbotyh"
@@ -10,6 +9,14 @@ source .env
 
 google_gemini_api_key="${Google_Gemini_API_Key}"
 telegram_bot_token="${Telegram_Bot_Token}"
+
+if [ -n "$Python_Venv_Path" ]; then
+    venv_dir="${Python_Venv_Path}"
+fi
+
+if [ -n "$Python_Bin_Path" ]; then
+    python_bin_path="$Python_Bin_Path"
+fi
 
 echo "=============================="
 echo "Prapare to setup telegram bot"
@@ -27,16 +34,16 @@ fi
 
 # Check Virtual Environment exist
 if [ -d "$venv_dir" ]; then
-  echo "Virtual Environment already exist"
-  exit 1
+    echo "Virtual Environment already exist"
+    exit 1
 fi
 
 # created virtual environment
 $python_bin_path -m venv "$venv_dir"
 if [ $? -eq 0 ]; then
-  echo "Successfully created virtual environment."
+    echo "Successfully created virtual environment."
 else
-  echo "Failed to create virtual environment."
+    echo "Failed to create virtual environment."
 fi
 
 source $venv_dir/bin/activate


### PR DESCRIPTION
This PR based on
https://github.com/yihong0618/tg_bot_collections/issues/14

1. add custom python path (python version) to env 
 增加 Python_Bin_Path 变量用于切换 已安装的python 不同的版本. 推荐安装python3.10

2. add run.sh script to run without systemd service
增加 run.sh  功能为不使用 systemd.service 方式的命令行方式运行.  包括安装python虚拟环境 方便调试

其他问题:
发现setup.sh 和 .env.example 文件 有时会从LF 换行 变成 CRLF 换行模式 导致脚本在linux 无法运行 需要注意编辑器设置 
可以在项目增加一个 .editorconfig 配置 指定换行模式为LF

