### PR TITLE
feat: add custom python version for setup.sh

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+
+[*.sh]
+indent_style = space
+indent_size = 4
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for yihong0618's channel: https://t.me/hyi0618
 
 ## HOW TO Install and Run
 
-### Run with systemd service
+### Run with systemd service with Python virtualenv environment
 
 1. Git clone this repo
 2. cd tg_bot_collections
@@ -31,15 +31,23 @@ for yihong0618's channel: https://t.me/hyi0618
 4. Edit .env file and change the following variables
     - Google_Gemini_API_Key (Google Gemini API KEY)
     - Telegram_Bot_Token (Telegram Bot Token)
-5. Run ```chmod +x setup.sh && ./setup.sh``` or ``` bash setup.sh ``` to install and run
+    - Python_Bin_Path (If you install python alternative version, you can use this to specify the python bin path. Default is blank or /usr/bin/python3)
+    - Python_Venv_Path (Python virtualenv path. Default is venv)
 
-6. Run ```systemctl status tgbotyh``` to check the status
-7. Run ```systemctl start tgbotyh``` to start the service
-8. Run ```systemctl stop tgbotyh``` to stop the service
-9. Run ```systemctl restart tgbotyh``` to restart the service
+5. Run ```chmod +x setup.sh && ./setup.sh``` or ``` bash setup.sh 1 ``` to install and run
+6. Next time, you can run ```./setup.sh``` or ``` bash setup.sh ``` to restart / stop the tg_bot_collections service and check the status or log
+7. you can also run ```./setup.sh 4 ``` to restart service, ```./setup.sh 5 ``` to stop, ```./setup.sh 7 ``` to check the log
+
+### Run with command line with Python virtualenv environment
+1. Git clone this repo
+2. cd tg_bot_collections
+3. Copy file .env.example to .env 
+4. Edit .env file and change the following variables (Same as above that Run with systemd service)
+5. Run ```chmod +x setup.sh && ./setup.sh``` or ``` bash setup.sh 2 ``` to install and run
+6. Ctrl + C to quit and Run ```deactivate``` to exit the virtualenv environment
+7. Next time, you can run ```./setup.sh``` or ``` bash setup.sh ``` to restart / stop the tg_bot_collections service and check the status or log
 
 ### Manually install 
-
 1. pip install -r requirements.txt
 2. Get tg token, ask Google or ChatGPT, need get it from [BotFather](https://t.me/BotFather)
 3. export GOOGLE_GEMINI_KEY=${your_google_gemini_apikey}
@@ -74,4 +82,3 @@ for yihong0618's channel: https://t.me/hyi0618
 ## Appreciation
 
 - Thank you, that's enough. Just enjoy it.
-

--- a/setup.sh
+++ b/setup.sh
@@ -2,7 +2,6 @@
 
 python_bin_path="$(which python3)"
 project_path="$(pwd)"
-
 service_name="tgbotyh"
 
 source .env

--- a/setup.sh
+++ b/setup.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 python_bin_path="$(which python3)"
-venv_dir="venv"
-
 project_path="$(pwd)"
+
 service_name="tgbotyh"
 
 source .env
@@ -11,14 +10,21 @@ source .env
 google_gemini_api_key="${Google_Gemini_API_Key}"
 telegram_bot_token="${Telegram_Bot_Token}"
 
-echo "=============================="
-echo "Prapare to setup telegram bot"
-echo ""
-echo "Project path: $project_path"
-echo "Python bin path: $python_bin_path"
-echo "Google_Gemini_API_Key: $Google_Gemini_API_Key"
-echo "Telegram Bot Token: $Telegram_Bot_Token"
-echo ""
+if [ -n "$Python_Venv_Path" ]; then
+    venv_dir="${Python_Venv_Path}"
+fi
+
+if [ -n "$Python_Bin_Path" ]; then
+    python_bin_path="$Python_Bin_Path"
+fi
+
+if [ -n "$Python_Venv_Path" ]; then
+    venv_dir="${Python_Venv_Path}"
+fi
+
+if [ -n "$Python_Bin_Path" ]; then
+    python_bin_path="$Python_Bin_Path"
+fi
 
 sudoCmd=""
 if [[ $(/usr/bin/id -u) -ne 0 ]]; then
@@ -76,10 +82,49 @@ function getLinuxOSRelease(){
         osSystemPackage="yum"
         osSystemMdPath="/usr/lib/systemd/system/"
     fi
-
 }
 
-cat > ${osSystemMdPath}${service_name}.service <<-EOF
+function installPythonVirtualEnv(){
+    echo
+    echo "=============================="
+    echo "Prapare to Install telegram bot"
+    echo
+    echo "Project path: $project_path"
+    echo "Python bin path: $python_bin_path"
+    echo "Google_Gemini_API_Key: $Google_Gemini_API_Key"
+    echo "Telegram Bot Token: $Telegram_Bot_Token"
+    echo
+
+    # Check Virtual Environment exist
+    if [ -d "$venv_dir" ]; then
+        echo "Virtual Environment already exist"
+        if [ -z "$1" ]; then
+            exit 1
+        else
+            source $venv_dir/bin/activate
+        fi
+    else
+        # created virtual environment
+        echo "Creating virtual environment..."
+        $python_bin_path -m venv "$venv_dir"
+
+        if [ $? -eq 0 ]; then
+            echo "Successfully created virtual environment."
+
+            source $venv_dir/bin/activate
+            python -m pip install --upgrade pip
+            pip install -r requirements.txt
+        else
+            echo "Failed to create virtual environment."
+            exit 1
+        fi
+    fi
+}
+
+function installSystemd(){
+    installPythonVirtualEnv
+
+    cat > ${osSystemMdPath}${service_name}.service <<-EOF
 
 [Unit]
 Description=$service_name service
@@ -101,15 +146,134 @@ RestartSec=30
 WantedBy=multi-user.target
 EOF
 
-${sudoCmd} chmod +x ${osSystemMdPath}${service_name}.service
-${sudoCmd} systemctl daemon-reload
-${sudoCmd} systemctl start ${service_name}.service
+    ${sudoCmd} chmod +x ${osSystemMdPath}${service_name}.service
+    ${sudoCmd} systemctl daemon-reload
+    ${sudoCmd} systemctl enable ${service_name}.service
+    ${sudoCmd} systemctl start ${service_name}.service
 
-echo ""
-echo "${service_name}.service running successfully" 
-echo ""
-echo "Run following command to start / stop telegram bot"
-echo "Start: systemctl start ${service_name}.service"
-echo "Stop: systemctl stop ${service_name}.service"
-echo "Check running status: systemctl status ${service_name}.service"
-echo "=============================="
+    echo
+    echo "${service_name}.service running successfully"
+    echo
+    echo "Run following command to start / stop telegram bot"
+    echo "Start: systemctl start ${service_name}.service"
+    echo "Stop: systemctl stop ${service_name}.service"
+    echo "Check running status: systemctl status ${service_name}.service"
+    echo "=============================="
+}
+function uninstallSystemd(){
+    ${sudoCmd} systemctl stop ${service_name}.service
+    ${sudoCmd} systemctl disable ${service_name}.service
+    ${sudoCmd} rm -rf ${osSystemMdPath}${service_name}.service
+    ${sudoCmd} systemctl daemon-reload
+}
+
+function installCommandLine(){
+    installPythonVirtualEnv "noexit"
+
+    echo
+    echo "=============================="
+    export GOOGLE_GEMINI_KEY=$google_gemini_api_key
+    python tg.py "${telegram_bot_token}"
+}
+
+function runSystemd(){
+    echo
+    if [ "$1" == "start" ]; then
+        echo "systemctl start ${service_name}.service"
+        ${sudoCmd} systemctl start ${service_name}.service
+
+    elif [ "$1" == "restart" ]; then
+        echo "systemctl restart ${service_name}.service"
+        ${sudoCmd} systemctl restart ${service_name}.service
+
+    elif [ "$1" == "stop" ]; then
+        echo "systemctl stop ${service_name}.service"
+        ${sudoCmd} systemctl stop ${service_name}.service
+
+    elif [ "$1" == "status" ]; then
+        echo "systemctl status ${service_name}.service"
+        ${sudoCmd} systemctl status ${service_name}.service
+
+    else
+        echo "journalctl -n 30 -u ${service_name}.service "
+        ${sudoCmd} journalctl -n 30 -u ${service_name}.service
+    fi
+    echo
+}
+
+function start_menu(){
+    clear
+
+    echo "=============================="
+    echo " 1. Install telegram bot and Run with Systemd Service"
+    echo " 2. Install and Run with Command Line"
+    echo
+    echo " 3. Uninstall telegram bot and Systemd Service"
+    echo
+    echo " 4. Restart ${service_name} Systemd Service"
+    echo " 5. Stop ${service_name} Systemd Service"
+    echo " 6. Check Status of ${service_name} Systemd Service"
+    echo " 7. Show Log of ${service_name} Systemd Service"
+    echo
+    echo " 0. exit"
+
+    echo
+    read -r -p "Please input number:" menuNumberInput
+    case "$menuNumberInput" in
+        1 )
+            installSystemd
+        ;;
+        2 )
+            installCommandLine
+        ;;
+        3 )
+            uninstallSystemd
+        ;;
+        4 )
+            runSystemd "restart"
+        ;;
+        5 )
+            runSystemd "stop"
+        ;;
+        6 )
+            runSystemd "status"
+        ;;
+        7 )
+            runSystemd
+        ;;
+        0 )
+            exit 1
+        ;;
+        * )
+            clear
+            echo "Please input correct number !"
+            sleep 2s
+            start_menu
+        ;;
+    esac
+}
+
+function showMenu(){
+
+        if [ -z "$1" ]; then
+            start_menu
+        elif [ "$1" == "1" ]; then
+            installSystemd
+        elif [ "$1" == "2" ]; then
+            installCommandLine
+        elif [ "$1" == "3" ]; then
+            uninstallSystemd
+        elif [ "$1" == "4" ]; then
+            runSystemd "restart"
+        elif [ "$1" == "5" ]; then
+            runSystemd "stop"
+        elif [ "$1" == "6" ]; then
+            runSystemd "status"
+        elif [ "$1" == "7" ]; then
+            runSystemd
+        else
+            start_menu
+        fi
+}
+
+showMenu $1


### PR DESCRIPTION
This PR based on
https://github.com/yihong0618/tg_bot_collections/issues/14

1. add custom python path (python version) to env 
 增加 Python_Bin_Path 变量用于切换 已安装的python 不同的版本. 推荐安装python3.10

2. add setup.sh script to run without systemd service
增加功能: 不使用 systemd.service 方式的命令行方式运行.  包括安装python虚拟环境 方便调试

3. 其他问题:
发现setup.sh 和 .env.example 文件 有时会从LF 换行 变成 CRLF 换行模式 导致脚本在linux 无法运行 需要注意编辑器设置 
在项目增加一个 .editorconfig 配置 指定换行模式为LF

同时建议关闭git 的 autocrlf 
``` git config --system core.autocrlf false ```
https://stackoverflow.com/questions/1967370/git-replacing-lf-with-crlf


由于一些原因之前的pr被自动关闭了 只能重新发一个PR了.  
因为 由于CRLF和LF的Merge 问题导致无法 git squash 合并Merge的提交，
为了提交整洁 因此我开了一个新分支dev2   把dev分支删了重新创建的dev分支 导致原来PR被自动关闭了。


