### PR TITLE
Add priority attribute to handler, sort and load handler by priority.

### DIFF
--- a/handlers/useful.py
+++ b/handlers/useful.py
@@ -13,6 +13,9 @@ from . import *
 
 from telegramify_markdown.customize import markdown_symbol
 
+# Define the load priority, lower numbers have higher priority
+load_priority = 1000
+
 # If you want, Customizing the head level 1 symbol
 markdown_symbol.head_level_1 = "📌"
 markdown_symbol.link = "🔗"  # If you want, Customizing the link symbol
@@ -196,7 +199,7 @@ def latest_handle_messages(message: Message, bot: TeleBot):
     elif message.text.startswith(
         (
             "md",
-            "chatgpt",
+            "gpt",
             "gemini",
             "qwen",
             "map",


### PR DESCRIPTION
Add priority attribute to handler, sort and load handler by priority.
- Set a low load priority in handlers/useful.py to ensure it loads last. (ensure 'latest_handle_messages' registered last to prevent other commands from failing.)

How to reproduce the situation where other commands are not functioning properly?
- In the `useful.py`, set the priority to high priority(`load_priority=1`)

